### PR TITLE
feat(sse): Add core SSE handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +392,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -400,14 +434,21 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum",
  "broker",
  "chrono",
  "dotenvy",
+ "futures-util",
  "jsonwebtoken",
+ "prost",
+ "prost-types",
+ "rand 0.9.2",
  "redis",
  "rsa",
+ "sentry_protos",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tower-http",
@@ -904,7 +945,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1191,8 +1232,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1202,7 +1253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1212,6 +1273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1275,7 +1345,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1399,7 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2024"
 [workspace.dependencies]
 sentry_protos = "0.3.5"
 anyhow = "1.0.99"
+async-stream = "0.3.5"
 async-trait = "0.1.89"
 axum = "0.8.4"
 chrono = "0.4.42"
@@ -47,5 +48,4 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.131"
-async-stream = "0.3.5"
 dotenvy = "0.15.7"

--- a/services/gateway/Cargo.toml
+++ b/services/gateway/Cargo.toml
@@ -5,14 +5,21 @@ edition.workspace = true
 
 [dependencies]
 broker = { path = "../../shared/broker" }
+sentry_protos = { workspace = true }
 anyhow = { workspace = true }
+async-stream = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 dotenvy = { workspace = true }
+futures-util = { workspace = true }
 jsonwebtoken = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+rand = { workspace = true }
 redis = { workspace = true }
 rsa = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }

--- a/services/gateway/src/handlers/mod.rs
+++ b/services/gateway/src/handlers/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod sse;

--- a/services/gateway/src/handlers/sse.rs
+++ b/services/gateway/src/handlers/sse.rs
@@ -1,0 +1,552 @@
+use prost::Message;
+use prost_types::value::Kind;
+use serde_json::json;
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{
+        Sse,
+        sse::{Event, KeepAlive},
+    },
+};
+use broker::{RedisOperations, StreamEvents, StreamKey};
+use futures_util::Stream;
+use rand::{Rng, rng};
+use redis::streams::StreamReadOptions;
+use sentry_protos::conduit::v1alpha::PublishRequest;
+use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::{
+    auth::{TokenValidationError, validate_token},
+    state::AppState,
+};
+
+const STREAM_BLOCK_MS: usize = 1000;
+const STREAM_MAX_EVENTS: usize = 20;
+const MAX_CONSECUTIVE_ERRORS: u64 = 10;
+const ERROR_BACKOFF_BASE_MS: u64 = 100;
+const JITTER_MS_MIN: u64 = 50;
+const JITTER_MS_MAX: u64 = 500;
+
+fn proto_struct_to_json(s: Option<&prost_types::Struct>) -> serde_json::Value {
+    match s {
+        None => serde_json::Value::Null,
+        Some(s) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in &s.fields {
+                map.insert(k.clone(), proto_value_to_json(v));
+            }
+            serde_json::Value::Object(map)
+        }
+    }
+}
+
+fn proto_value_to_json(v: &prost_types::Value) -> serde_json::Value {
+    match &v.kind {
+        Some(Kind::NullValue(_)) => serde_json::Value::Null,
+        Some(Kind::NumberValue(n)) => json!(n),
+        Some(Kind::StringValue(s)) => serde_json::Value::String(s.clone()),
+        Some(Kind::BoolValue(b)) => serde_json::Value::Bool(*b),
+        Some(Kind::StructValue(s)) => proto_struct_to_json(Some(s)),
+        Some(Kind::ListValue(list)) => {
+            serde_json::Value::Array(list.values.iter().map(proto_value_to_json).collect())
+        }
+        None => serde_json::Value::Null,
+    }
+}
+
+#[derive(Serialize)]
+struct SSEEvent {
+    event_type: String,
+    message_id: Uuid,
+    channel_id: Uuid,
+    phase: String,
+    sequence: u64,
+    payload: serde_json::Value,
+}
+
+pub fn create_event_stream<R: RedisOperations>(
+    redis: Arc<R>,
+    org_id: u64,
+    channel_id: Uuid,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    let stream_key = StreamKey::new(org_id.to_string(), channel_id.to_string());
+    let stream_read_opts = StreamReadOptions::default()
+        .block(STREAM_BLOCK_MS)
+        .count(STREAM_MAX_EVENTS);
+    let mut last_id = "0-0".to_string();
+    let mut consecutive_errors = 0;
+
+    async_stream::stream! {
+        'outer: loop {
+            let stream_events: StreamEvents = match redis.poll(&stream_key, &last_id, &stream_read_opts).await {
+                Ok(e) => {
+                    consecutive_errors = 0;
+                    e
+                }
+                Err(_) => {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                        // TODO: use a proper event schema
+                        yield Ok(Event::default()
+                            .event("error")
+                            .data("Too many errors, closing stream"));
+                        break 'outer;
+                    }
+                    sleep(Duration::from_millis(ERROR_BACKOFF_BASE_MS * consecutive_errors)).await;
+                    continue;
+                }
+            };
+            if stream_events.events.is_empty() {
+                let jitter_ms = rng().random_range(JITTER_MS_MIN..=JITTER_MS_MAX);
+                sleep(Duration::from_millis(jitter_ms)).await;
+                continue;
+            }
+            for (event_id, event_data) in stream_events.events {
+                let publish_request: PublishRequest = match PublishRequest::decode(&*event_data) {
+                    Ok(pr) => pr,
+                    Err(e) => {
+                        eprintln!("Failed to decode protobuf for event {}: {}", event_id, e);
+                        last_id = event_id;
+                        continue;
+                    }
+                };
+
+                let message_id = match Uuid::parse_str(&publish_request.message_id) {
+                    Ok(id) => id,
+                    Err(_) => {
+                        eprintln!("Invalid message_id UUID: {}", publish_request.message_id);
+                        last_id = event_id;
+                        continue;
+                    }
+                };
+
+                let channel_id = match Uuid::parse_str(&publish_request.channel_id) {
+                    Ok(id) => id,
+                    Err(_) => {
+                        eprintln!("Invalid channel_id UUID: {}", publish_request.channel_id);
+                        last_id = event_id;
+                        continue;
+                    }
+                };
+
+                let sse_event = SSEEvent {
+                    event_type: "stream".to_string(),
+                    message_id,
+                    channel_id,
+                    phase: publish_request.phase().as_str_name().to_string(),
+                    sequence: publish_request.sequence,
+                    payload: proto_struct_to_json(publish_request.payload.as_ref()),
+                };
+
+                let sse_event_json = match serde_json::to_string(&sse_event) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        eprintln!("Failed to serialize SSE Event {}", e);
+                        continue;
+                    }
+                };
+
+                yield Ok(Event::default()
+                    .event(&sse_event.event_type)
+                    .id(&event_id)
+                    .data(sse_event_json)
+                );
+
+                last_id = event_id.clone();
+
+                if matches!(publish_request.phase(), sentry_protos::conduit::v1alpha::Phase::End) {
+                    break 'outer;
+                }
+            }
+        };
+    }
+}
+
+#[derive(Deserialize)]
+pub struct SSEQuery {
+    channel_id: Uuid,
+    token: String,
+}
+
+pub async fn sse_handler(
+    State(state): State<AppState>,
+    Path(org_id): Path<u64>,
+    Query(q): Query<SSEQuery>,
+) -> Result<Sse<impl Stream<Item = Result<Event, axum::Error>>>, (StatusCode, String)> {
+    let claims = validate_token(
+        &q.token,
+        org_id,
+        q.channel_id,
+        &state.jwt_config.public_key_pem,
+        &state.jwt_config.expected_issuer,
+        &state.jwt_config.expected_audience,
+    )
+    .map_err(|e| match e {
+        TokenValidationError::TokenExpired => {
+            (StatusCode::UNAUTHORIZED, "Token expired".to_string())
+        }
+        TokenValidationError::OrgIdMismatch { .. }
+        | TokenValidationError::ChannelIdMismatch { .. } => {
+            (StatusCode::FORBIDDEN, "Invalid token claims".to_string())
+        }
+        _ => (StatusCode::UNAUTHORIZED, "Invalid token".to_string()),
+    })?;
+
+    let stream = create_event_stream(Arc::new(state.redis), claims.org_id, claims.channel_id);
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    mod proto_conversion_tests {
+        use super::super::*;
+        use prost_types::{ListValue, Struct, Value};
+        use std::collections::BTreeMap;
+
+        #[test]
+        fn test_proto_value_to_json_basic_types() {
+            let v = Value {
+                kind: Some(Kind::NullValue(0)),
+            };
+            assert_eq!(proto_value_to_json(&v), json!(null));
+
+            let v = Value { kind: None };
+            assert_eq!(proto_value_to_json(&v), json!(null));
+
+            let v = Value {
+                kind: Some(Kind::BoolValue(true)),
+            };
+            assert_eq!(proto_value_to_json(&v), json!(true));
+
+            let v = Value {
+                kind: Some(Kind::NumberValue(42.0)),
+            };
+            assert_eq!(proto_value_to_json(&v), json!(42.0));
+
+            let v = Value {
+                kind: Some(Kind::StringValue("test".to_string())),
+            };
+            assert_eq!(proto_value_to_json(&v), json!("test"));
+        }
+
+        #[test]
+        fn test_proto_value_to_json_list() {
+            let values = vec![
+                Value {
+                    kind: Some(Kind::NumberValue(1.0)),
+                },
+                Value {
+                    kind: Some(Kind::StringValue("two".to_string())),
+                },
+                Value {
+                    kind: Some(Kind::BoolValue(true)),
+                },
+            ];
+            let v = Value {
+                kind: Some(Kind::ListValue(ListValue { values })),
+            };
+            assert_eq!(proto_value_to_json(&v), json!([1.0, "two", true]));
+        }
+
+        #[test]
+        fn test_proto_struct_to_json_null() {
+            assert_eq!(proto_struct_to_json(None), json!(null));
+        }
+
+        #[test]
+        fn test_proto_struct_to_json_empty() {
+            let proto_struct = Struct {
+                fields: BTreeMap::new(),
+            };
+            assert_eq!(proto_struct_to_json(Some(&proto_struct)), json!({}));
+        }
+
+        #[test]
+        fn test_proto_struct_to_json_with_fields() {
+            let mut fields = BTreeMap::new();
+            fields.insert(
+                "name".to_string(),
+                Value {
+                    kind: Some(Kind::StringValue("test".to_string())),
+                },
+            );
+            fields.insert(
+                "count".to_string(),
+                Value {
+                    kind: Some(Kind::NumberValue(42.0)),
+                },
+            );
+
+            let proto_struct = Struct { fields };
+            let result = proto_struct_to_json(Some(&proto_struct));
+
+            assert_eq!(
+                result,
+                json!({
+                    "name": "test",
+                    "count": 42.0,
+                })
+            );
+        }
+
+        #[test]
+        fn test_proto_struct_to_json_nested() {
+            let mut inner_fields = BTreeMap::new();
+            inner_fields.insert(
+                "street".to_string(),
+                Value {
+                    kind: Some(Kind::StringValue("45 Fremont St".to_string())),
+                },
+            );
+            inner_fields.insert(
+                "city".to_string(),
+                Value {
+                    kind: Some(Kind::StringValue("San Francisco".to_string())),
+                },
+            );
+
+            let mut outer_fields = BTreeMap::new();
+            outer_fields.insert(
+                "company".to_string(),
+                Value {
+                    kind: Some(Kind::StringValue("Sentry".to_string())),
+                },
+            );
+            outer_fields.insert(
+                "address".to_string(),
+                Value {
+                    kind: Some(Kind::StructValue(Struct {
+                        fields: inner_fields,
+                    })),
+                },
+            );
+            outer_fields.insert(
+                "employee_count".to_string(),
+                Value {
+                    kind: Some(Kind::NumberValue(300.0)),
+                },
+            );
+
+            let proto_struct = Struct {
+                fields: outer_fields,
+            };
+            let result = proto_struct_to_json(Some(&proto_struct));
+
+            assert_eq!(
+                result,
+                json!({
+                    "company": "Sentry",
+                    "address": {
+                        "street": "45 Fremont St",
+                        "city": "San Francisco",
+                    },
+                    "employee_count": 300.0,
+                })
+            );
+        }
+    }
+
+    mod sse_stream_tests {
+        use std::collections::BTreeMap;
+
+        use super::super::*;
+        use broker::{MockRedisOperations, StreamEvents};
+        use futures_util::StreamExt;
+        use prost_types::{Struct, Timestamp};
+        use sentry_protos::conduit::v1alpha::Phase;
+
+        #[tokio::test]
+        async fn test_create_event_stream_with_events() {
+            let channel_id = Uuid::new_v4();
+
+            let start_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.clone().to_string(),
+                phase: Phase::Start.into(),
+                sequence: 1,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467200,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+            let delta_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.clone().to_string(),
+                phase: Phase::Delta.into(),
+                sequence: 2,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467400,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+            let end_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.clone().to_string(),
+                phase: Phase::End.into(),
+                sequence: 2,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467600,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+
+            let mut mock_redis = MockRedisOperations::new();
+            mock_redis.expect_poll().returning(move |_, _, _| {
+                Ok(StreamEvents {
+                    events: vec![
+                        ("1-0".to_string(), start_publish_request.encode_to_vec()),
+                        ("2-0".to_string(), delta_publish_request.encode_to_vec()),
+                        ("3-0".to_string(), end_publish_request.encode_to_vec()),
+                    ],
+                })
+            });
+
+            let mut stream = Box::pin(create_event_stream(Arc::new(mock_redis), 123, channel_id));
+
+            let mut events = vec![];
+            while let Some(result) = stream.next().await {
+                events.push(result.expect("Event should be Ok"));
+            }
+
+            assert_eq!(events.len(), 3);
+        }
+
+        #[tokio::test]
+        async fn test_create_event_stream_errors_close_stream() {
+            let mut mock_redis = MockRedisOperations::new();
+
+            mock_redis
+                .expect_poll()
+                .times(MAX_CONSECUTIVE_ERRORS as usize)
+                .returning(|_, _, _| {
+                    let redis_err =
+                        redis::RedisError::from((redis::ErrorKind::IoError, "Connection refused"));
+                    Err(broker::Error::Redis(redis_err))
+                });
+
+            let mut stream = Box::pin(create_event_stream(
+                Arc::new(mock_redis),
+                123,
+                Uuid::new_v4(),
+            ));
+
+            let mut events = vec![];
+            while let Some(result) = stream.next().await {
+                events.push(result.expect("Event should be Ok"));
+            }
+
+            // Only one event is expected: error
+            assert_eq!(events.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_create_event_stream_invalid_events_are_skipped() {
+            let channel_id = Uuid::new_v4();
+            let end_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.to_string(),
+                phase: Phase::End.into(),
+                sequence: 2,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467600,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+
+            let mut mock_redis = MockRedisOperations::new();
+            mock_redis.expect_poll().returning(move |_, _, _| {
+                Ok(StreamEvents {
+                    events: vec![
+                        ("1-0".to_string(), vec![0xFF, 0xBA]), // Invalid proto
+                        ("2-0".to_string(), end_publish_request.encode_to_vec()),
+                    ],
+                })
+            });
+
+            let mut stream = Box::pin(create_event_stream(Arc::new(mock_redis), 123, channel_id));
+
+            let mut events = vec![];
+            while let Some(result) = stream.next().await {
+                events.push(result.expect("Event should be Ok"));
+            }
+
+            assert_eq!(events.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_create_event_stream_intermittent_errors_recovery() {
+            let channel_id = Uuid::new_v4();
+            let start_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.clone().to_string(),
+                phase: Phase::Start.into(),
+                sequence: 1,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467200,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+            let end_publish_request = PublishRequest {
+                message_id: Uuid::new_v4().to_string(),
+                channel_id: channel_id.to_string(),
+                phase: Phase::End.into(),
+                sequence: 2,
+                client_timestamp: Some(Timestamp {
+                    seconds: 1736467600,
+                    nanos: 0,
+                }),
+                payload: Some(Struct {
+                    fields: BTreeMap::new(),
+                }),
+            };
+
+            let mut mock_redis = MockRedisOperations::new();
+            let mut num_failures = 0;
+            const EXPECTED_FAILURES: u32 = 5;
+            mock_redis.expect_poll().returning(move |_, _, _| {
+                if num_failures < EXPECTED_FAILURES {
+                    num_failures += 1;
+                    let redis_err =
+                        redis::RedisError::from((redis::ErrorKind::IoError, "Connection refused"));
+                    return Err(broker::Error::Redis(redis_err));
+                }
+                Ok(StreamEvents {
+                    events: vec![
+                        ("1-0".to_string(), start_publish_request.encode_to_vec()),
+                        ("2-0".to_string(), end_publish_request.encode_to_vec()),
+                    ],
+                })
+            });
+
+            let mut stream = Box::pin(create_event_stream(Arc::new(mock_redis), 123, channel_id));
+
+            let mut events = vec![];
+            while let Some(result) = stream.next().await {
+                events.push(result.expect("Event should be Ok"));
+            }
+
+            assert_eq!(events.len(), 2);
+        }
+    }
+}

--- a/services/gateway/src/state.rs
+++ b/services/gateway/src/state.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use broker::RedisClient;
 use tokio::time::Instant;
 
@@ -5,6 +7,28 @@ use tokio::time::Instant;
 pub struct AppState {
     pub redis: RedisClient,
     pub start_time: Instant,
+    pub jwt_config: JwtConfig,
+}
+
+#[derive(Clone)]
+pub struct JwtConfig {
+    pub expected_issuer: String,
+    pub expected_audience: String,
+    pub public_key_pem: String,
+}
+
+impl JwtConfig {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let issuer = env::var("JWT_ISSUER")?;
+        let audience = env::var("JWT_AUDIENCE")?;
+        let public_key_pem = env::var("JWT_PUBLIC_KEY")?;
+
+        Ok(Self {
+            expected_issuer: issuer,
+            expected_audience: audience,
+            public_key_pem,
+        })
+    }
 }
 
 #[derive(Clone)]

--- a/shared/broker/src/lib.rs
+++ b/shared/broker/src/lib.rs
@@ -43,7 +43,7 @@ pub trait RedisOperations: Send + Sync {
         &self,
         key: &StreamKey,
         last_id: &str,
-        opts: StreamReadOptions,
+        opts: &StreamReadOptions,
     ) -> Result<StreamEvents>;
     async fn set_ttl(&self, key: &StreamKey, seconds: i64) -> Result<bool>;
 }
@@ -80,11 +80,11 @@ impl RedisOperations for RedisClient {
         &self,
         key: &StreamKey,
         last_id: &str,
-        opts: StreamReadOptions,
+        opts: &StreamReadOptions,
     ) -> Result<StreamEvents> {
         let mut conn = self.conn.clone();
         let reply: StreamReadReply = conn
-            .xread_options(&[&key.as_redis_key()], &[last_id], &opts)
+            .xread_options(&[&key.as_redis_key()], &[last_id], opts)
             .await?;
         let events = reply
             .keys


### PR DESCRIPTION
Adds the core SSE handler logic.

* Add `/event/{org_id}` SSE endpoint for streaming Redis-backed events
* Added basic parsing of proto structs
* Implemented JWT-based auth from #5
* Added the first layer of error handling and circuit breakers (more to come)
* Included comprehensive testing