### PR TITLE
security: use distroless as final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,25 @@ COPY shared shared/
 
 RUN cargo build --release --bin ${SERVICE_NAME}
 
+# Development image
+FROM rust:1 AS dev
+
+WORKDIR /app
+
+ARG SERVICE_NAME
+
+RUN groupadd --gid 1000 conduit && useradd --uid 1000 --gid 1000 conduit
+
+COPY --from=build /app/target/release/${SERVICE_NAME} /app/service
+
+RUN chown conduit:conduit /app/service
+
+USER conduit:conduit
+
+EXPOSE 8080
+
+CMD ["/app/service"]
+
 # Runtime image
 FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build image
-FROM rust:1-bookworm AS build
+FROM rust:1 AS build
+
 WORKDIR /app
 
 ARG SERVICE_NAME
@@ -10,22 +11,13 @@ COPY shared shared/
 
 RUN cargo build --release --bin ${SERVICE_NAME}
 
-# Runtime image
-FROM debian:bookworm-slim
+# Runtime image  
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 ARG SERVICE_NAME
-
-RUN apt-get update && apt-get install -y --no-install-recommends \ 
-    openssl ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN groupadd --gid 1000 conduit && useradd --uid 1000 --gid 1000 conduit
 
 COPY --from=build /app/target/release/${SERVICE_NAME} /usr/local/bin/service
 
 EXPOSE 8080
-
-WORKDIR /app
-USER conduit:conduit
 
 CMD ["/usr/local/bin/service"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY shared shared/
 RUN cargo build --release --bin ${SERVICE_NAME}
 
 # Runtime image
-FROM gcr.io/distroless/cc-debian12:nonroot as runtime
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
 ARG SERVICE_NAME
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ COPY shared shared/
 
 RUN cargo build --release --bin ${SERVICE_NAME}
 
-# Runtime image  
-FROM gcr.io/distroless/cc-debian12:nonroot
+# Runtime image
+FROM gcr.io/distroless/cc-debian12:nonroot as runtime
 
 ARG SERVICE_NAME
 


### PR DESCRIPTION
Using distroless as a minimal image to reduce security vulnerabilities and attack surface area.