### PR TITLE
ref(broker): Update stream key types and usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "mockall",
  "redis",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -1209,6 +1210,7 @@ dependencies = [
  "serde",
  "tokio",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]

--- a/services/gateway/src/handlers/sse.rs
+++ b/services/gateway/src/handlers/sse.rs
@@ -74,7 +74,7 @@ pub fn create_event_stream<R: RedisOperations>(
     org_id: u64,
     channel_id: Uuid,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
-    let stream_key = StreamKey::new(org_id.to_string(), channel_id.to_string());
+    let stream_key = StreamKey::new(org_id, channel_id);
     let stream_read_opts = StreamReadOptions::default()
         .block(STREAM_BLOCK_MS)
         .count(STREAM_MAX_EVENTS);

--- a/services/publish/Cargo.toml
+++ b/services/publish/Cargo.toml
@@ -16,3 +16,4 @@ redis = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
+uuid = { workspace = true }

--- a/shared/broker/Cargo.toml
+++ b/shared/broker/Cargo.toml
@@ -8,3 +8,4 @@ async-trait = { workspace = true }
 mockall = { workspace = true }
 redis = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/shared/broker/src/lib.rs
+++ b/shared/broker/src/lib.rs
@@ -8,7 +8,6 @@ use uuid::Uuid;
 
 const STREAM_DATA_FIELD: &str = "data";
 
-#[derive(Clone)]
 pub struct StreamKey {
     org_id: u64,
     channel_id: Uuid,

--- a/shared/broker/src/lib.rs
+++ b/shared/broker/src/lib.rs
@@ -4,16 +4,18 @@ use redis::streams::{StreamReadOptions, StreamReadReply};
 use redis::{AsyncCommands, from_redis_value};
 
 use mockall::automock;
+use uuid::Uuid;
 
 const STREAM_DATA_FIELD: &str = "data";
 
+#[derive(Clone)]
 pub struct StreamKey {
-    org_id: String,
-    channel_id: String,
+    org_id: u64,
+    channel_id: Uuid,
 }
 
 impl StreamKey {
-    pub fn new(org_id: String, channel_id: String) -> Self {
+    pub fn new(org_id: u64, channel_id: Uuid) -> Self {
         Self { org_id, channel_id }
     }
 


### PR DESCRIPTION
Updating stream key types to be more precise (u64 and Uuid) and updating the gateway and publish services to use these types.