### PR TITLE
feat(publish): Set ttl on end

### DIFF
--- a/services/publish/src/handlers/publish.rs
+++ b/services/publish/src/handlers/publish.rs
@@ -40,11 +40,11 @@ async fn do_publish<R: RedisOperations>(
         eprintln!("Failed to trim stream after publish: {}", e);
     }
 
-    if matches!(stream_event.phase(), Phase::End) {
-        if let Err(e) = redis.set_ttl(&stream_key, STREAM_TTL_SEC).await {
-            // TODO: Add proper error handling
-            eprintln!("Failed to set TTL for stream {}", e);
-        }
+    if matches!(stream_event.phase(), Phase::End)
+        && let Err(e) = redis.set_ttl(&stream_key, STREAM_TTL_SEC).await
+    {
+        // TODO: Add proper error handling
+        eprintln!("Failed to set TTL for stream {}", e);
     }
 
     Ok(id)


### PR DESCRIPTION
This change adds a TTL to the stream once it ends which assists with cleanup. This will work alongside a dedicated cleanup process coming in the future.