### PR TITLE
chore(gocd): use GitHub App credentials

### DIFF
--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-checks-githubactions-checkruns \
+checks-githubactions-checkruns2 \
   getsentry/conduit \
   "${GO_REVISION_CONDUIT_REPO}" \
   "build-gateway-prod-amd64" \

--- a/gocd/templates/pipelines/conduit.libsonnet
+++ b/gocd/templates/pipelines/conduit.libsonnet
@@ -23,7 +23,8 @@ function(region) {
             timeout: 10,
             elastic_profile_id: 'conduit',
             environment_variables: {
-              GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+              GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+              GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
             },
             tasks: [
               gocdtasks.script(importstr '../bash/check-github-runs.sh'),


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.